### PR TITLE
backport get_key_accounts for scatter to 0.17

### DIFF
--- a/api/handlers/state/getKeyAccounts.js
+++ b/api/handlers/state/getKeyAccounts.js
@@ -3,9 +3,9 @@ const {getCacheByHash} = require("../../helpers/functions");
 const numeric = require('eosjs/dist/eosjs-numeric');
 const ecc = require('eosjs-ecc');
 
-async function getKeyAccounts(fastify, request) {
+async function getKeyAccounts(fastify, public_Key) {
     const {redis, elasticsearch} = fastify;
-    let public_Key = request.query.public_key;
+
     if (!ecc.isValidPublic(public_Key)) {
         const err = new Error();
         err.statusCode = 400;
@@ -14,7 +14,7 @@ async function getKeyAccounts(fastify, request) {
     } else {
         public_Key = numeric.convertLegacyPublicKey(public_Key);
     }
-    const [cachedResponse, hash] = await getCacheByHash(redis, JSON.stringify(request.query));
+    const [cachedResponse, hash] = await getCacheByHash(redis, JSON.stringify(public_Key));
     if (cachedResponse) {
         return cachedResponse;
     }
@@ -73,7 +73,14 @@ module.exports = function (fastify, opts, next) {
     fastify.get('/get_key_accounts', {
         schema: getKeyAccountsSchema.GET
     }, async (request) => {
-        return getKeyAccounts(fastify, request);
+        return getKeyAccounts(fastify, request.query.public_key);
     });
+
+    fastify.post('/get_key_accounts', {
+        schema: getKeyAccountsSchema.POST
+    }, async (request) => {
+        return getKeyAccounts(fastify, request.body.public_key);
+    });
+
     next()
 };

--- a/api/schemas/get_key_accounts.js
+++ b/api/schemas/get_key_accounts.js
@@ -1,25 +1,55 @@
-exports.GET = {
-    description: 'get accounts by public key',
-    summary: 'get accounts by public key',
-    tags: ['state'],
-    querystring: {
-        type: 'object',
-        properties: {
-            "public_key": {
-                description: 'public key',
-                type: 'string'
-            },
-        },
-        required: ["public_key"]
-    },
-    response: {
-        200: {
+module.exports = {
+    GET: {
+        description: 'get accounts by public key',
+        summary: 'get accounts by public key',
+        tags: ['state'],
+        querystring: {
             type: 'object',
             properties: {
-                "account_names": {
-                    type: "array",
-                    items: {
-                        type: "string"
+                "public_key": {
+                    description: 'public key',
+                    type: 'string'
+                },
+            },
+            required: ["public_key"]
+        },
+        response: {
+            200: {
+                type: 'object',
+                properties: {
+                    "account_names": {
+                        type: "array",
+                        items: {
+                            type: "string"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    POST: {
+        description: 'get accounts by public key',
+        summary: 'get accounts by public key',
+        tags: ['state'],
+        body: {
+            type: 'object',
+            properties: {
+                "public_key": {
+                    description: 'public key',
+                    type: 'string'
+                },
+            },
+            required: ["public_key"]
+        },
+        response: {
+            200: {
+                type: 'object',
+                properties: {
+                    "account_names": {
+                        type: "array",
+                        items: {
+                            type: "string"
+                        }
                     }
                 }
             }


### PR DESCRIPTION
backports https://github.com/eosrio/Hyperion-History-API/commit/a04fdc8de4e5df023dbb454a615facf5d4131e3b
to 0.17 which is supports 1.7.x nodes.